### PR TITLE
Add PostgreSQL driver dependency and document database setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ API em Spring Boot para cadastro de clientes com localização geográfica e ger
 ## Pré-requisitos
 - Java 17
 - Maven 3.9+
+- PostgreSQL 14+
 
 ## Como executar
 ```bash
@@ -53,3 +54,25 @@ O documento OpenAPI em formato JSON está disponível em `http://localhost:8080/
 ```bash
 mvn test
 ```
+
+## Configuração do banco de dados PostgreSQL
+
+Para criar a estrutura necessária para a aplicação, execute o script abaixo em um servidor PostgreSQL:
+
+```sql
+CREATE DATABASE rotas;
+
+\c rotas;
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TABLE clientes (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    nome VARCHAR(255) NOT NULL,
+    endereco VARCHAR(255) NOT NULL,
+    latitude DOUBLE PRECISION NOT NULL,
+    longitude DOUBLE PRECISION NOT NULL
+);
+```
+
+> Obs.: O uso da extensão `uuid-ossp` permite gerar valores UUID diretamente no banco ao inserir novos clientes.

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,11 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.7.3</version>
+        </dependency>
+        <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.5.0</version>


### PR DESCRIPTION
## Summary
- add the PostgreSQL JDBC driver dependency to the Maven project
- document the PostgreSQL database and table creation SQL in the README

## Testing
- mvn -q -DskipTests package *(fails: Maven Central returned 403 Forbidden while resolving parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68e45cfa35e8832292ace0ae6029fe41