### PR TITLE
Configure Swagger documentation

### DIFF
--- a/src/main/java/com/rotasdanilov/rotas/config/OpenApiConfig.java
+++ b/src/main/java/com/rotasdanilov/rotas/config/OpenApiConfig.java
@@ -1,0 +1,31 @@
+package com.rotasdanilov.rotas.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI rotasOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Rotas Danilov API")
+                        .version("v1")
+                        .description("API para cadastro de clientes e otimização de rotas.")
+                        .contact(new Contact()
+                                .name("Equipe Rotas Danilov")
+                                .email("contato@rotasdanilov.com"))
+                        .license(new License()
+                                .name("Apache 2.0")
+                                .url("https://www.apache.org/licenses/LICENSE-2.0.html")))
+                .addServersItem(new Server()
+                        .url("http://localhost:8080")
+                        .description("Ambiente local"));
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.operationsSorter=method
+springdoc.swagger-ui.tagsSorter=alpha


### PR DESCRIPTION
## Summary
- add Springdoc OpenAPI configuration bean with project metadata
- configure Swagger UI and API docs endpoints via application properties

## Testing
- `mvn -q test` *(fails: unable to download parent POM from Maven Central in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e4618f6cf08322a72c22393ef9ecb3